### PR TITLE
Refactor hpss code and tests

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -1,14 +1,11 @@
 """
-Run the test suite like:
-    python test.py
-You'll get a statement printed
-if all of the tests pass.
+Run the test suite with `python test.py`
 """
 
 import os
-import sys
-import subprocess
 import shutil
+import subprocess
+import unittest
 from collections import Counter
 
 def write_file(name, contents):
@@ -16,7 +13,8 @@ def write_file(name, contents):
     Write contents to a file named name.
     """
     with open(name, 'w') as f:
-        f.write(contents)   
+        f.write(contents)
+
 
 def run_cmd(cmd):
     """
@@ -39,29 +37,10 @@ def run_cmd(cmd):
     print(err)
     return output, err
 
-def str_not_in(output, msg):
-    """
-    If the msg is not in the output string, then everything is fine.
-    """
-    if msg in output:
-        print('*'*40)
-        print('This was not supposed to be found: {}'.format(msg))
-        print('*'*40)
-        stop()
 
-def str_in(output, msg):
+def cleanup(hpss_path):
     """
-    If the msg is in the output string, then the everything is fine.
-    """
-    if not msg in output:
-        print('*'*40)
-        print('This was supposed to be found, but was not: {}'.format(msg))
-        print('*'*40)
-        stop()
-
-def cleanup():
-    """
-    After this script is ran, remove all created files, even those on the HPSS repo.
+    After the script has failed/run, remove all created files, even those on the HPSS repo.
     """
     print('Removing test files, both locally and at the HPSS repo')
     if os.path.exists('zstash_test'):
@@ -70,448 +49,594 @@ def cleanup():
         shutil.rmtree('zstash_test_backup')
     if os.path.exists('zstash'):
         shutil.rmtree('zstash')
-    cmd = 'hsi rm -R {}'.format(HPSS_PATH)
+    cmd = 'hsi rm -R {}'.format(hpss_path)
     run_cmd(cmd)
 
-def stop():
-    """
-    Cleanup and stop running this script.
-    """
-    cleanup()
-    sys.exit()
 
 # Compare content of two (unordered lists)
 # https://stackoverflow.com/questions/7828867/how-to-efficiently-compare-two-unordered-lists-not-sets-in-python
 def compare(s, t):
     return Counter(s) == Counter(t)
 
-# Makes this in the home dir of the user on HPSS.
-# Ex: /home/z/zshaheen/zstash_test
-HPSS_PATH='zstash_test'
 
-# Create files and directories
-for option in ['-v', '']:
-    print('Creating files {}.'.format(option))
-    cleanup()
-    os.mkdir('zstash_test')
-    os.mkdir('zstash_test/empty_dir')
-    os.mkdir('zstash_test/dir')
+class TestZStash(unittest.TestCase):
+    def stop(self, hpss_path, error_message):
+        """
+        Cleanup and stop running this script.
+        """
+        cleanup(hpss_path)
+        self.fail(error_message)
 
-    write_file('zstash_test/file0.txt', 'file0 stuff')
-    write_file('zstash_test/file_empty.txt', '')
-    write_file('zstash_test/dir/file1.txt', 'file1 stuff')
+    def str_not_in(self, cmd, hpss_path, output, msg):
+        """
+        If the msg is not in the output string, then everything is fine.
+        """
+        if msg in output:
+            print('*' * 40)
+            error_message = 'Command=`{}`. This was not supposed to be found: {}.'.format(cmd, msg)
+            print(error_message)
+            print('*' * 40)
+            self.stop(hpss_path, error_message)
 
-    if not os.path.lexists('zstash_test/file0_soft.txt'):
-        # If we symlink zstash_test/file0_soft.txt to zstash_test/file0.txt
-        # zstash_test/file0_soft.txt links to zstash_test/zstash_test/file0.txt
-        os.symlink('file0.txt', 'zstash_test/file0_soft.txt')
+    def str_in(self, cmd, hpss_path, output, msg):
+        """
+        If the msg is in the output string, then the everything is fine.
+        """
+        if msg not in output:
+            print('*' * 40)
+            error_message = 'Command=`{}`. This was supposed to be found, but was not: {}'.format(cmd, msg)
+            print(error_message)
+            print('*' * 40)
+            self.stop(hpss_path, error_message)
 
-    if not os.path.lexists('zstash_test/file0_soft_bad.txt'):
-        # If we symlink zstash_test/file0_soft.txt to zstash_test/file0.txt
-        # zstash_test/file0_soft.txt links to zstash_test/zstash_test/file0.txt
-        os.symlink('file0_that_doesnt_exist.txt', 'zstash_test/file0_soft_bad.txt')
+    def testZstashWithHPSS(self):
+        print('*' * 40)
+        print('testZstashWithHPSS')
+        print('*' * 40)
+        print('0. Setup')
+        # Makes this in the home dir of the user on HPSS.
+        # Ex: /home/z/zshaheen/zstash_test
+        hpss_path = 'zstash_test'
+        # Create files and directories
+        for option in ['-v', '']:
+            print('Creating files {}.'.format(option))
+            cleanup(hpss_path)
+            os.mkdir('zstash_test')
+            os.mkdir('zstash_test/empty_dir')
+            os.mkdir('zstash_test/dir')
 
-    if not os.path.lexists('zstash_test/file0_hard.txt'):
-        os.link('zstash_test/file0.txt', 'zstash_test/file0_hard.txt')
+            write_file('zstash_test/file0.txt', 'file0 stuff')
+            write_file('zstash_test/file_empty.txt', '')
+            write_file('zstash_test/dir/file1.txt', 'file1 stuff')
 
+            if not os.path.lexists('zstash_test/file0_soft.txt'):
+                # If we symlink zstash_test/file0_soft.txt to zstash_test/file0.txt
+                # zstash_test/file0_soft.txt links to zstash_test/zstash_test/file0.txt
+                os.symlink('file0.txt', 'zstash_test/file0_soft.txt')
 
-    print('Adding files to HPSS')
-    cmd = 'zstash create {} --hpss={} zstash_test'.format(option, HPSS_PATH)
-    output, err = run_cmd(cmd)
-    str_in(output+err, 'Transferring file to HPSS')
-    str_not_in(output+err, 'ERROR')
+            if not os.path.lexists('zstash_test/file0_soft_bad.txt'):
+                # If we symlink zstash_test/file0_soft.txt to zstash_test/file0.txt
+                # zstash_test/file0_soft.txt links to zstash_test/zstash_test/file0.txt
+                os.symlink('file0_that_doesnt_exist.txt', 'zstash_test/file0_soft_bad.txt')
 
+            if not os.path.lexists('zstash_test/file0_hard.txt'):
+                os.link('zstash_test/file0.txt', 'zstash_test/file0_hard.txt')
 
-print('Testing chgrp')
-GROUP = 'acme'
-for option in ['-v', '']:
-    print('Running zstash chgrp {}'.format(option))
-    cmd = 'zstash chgrp {} -R {} {}'.format(option, GROUP, HPSS_PATH)
-    output, err = run_cmd(cmd)
-    str_not_in(output+err, 'ERROR')
-    print('Now check that the files are in the {} group'.format(GROUP))
-    cmd = 'hsi ls -l {}'.format(HPSS_PATH)
-    output, err = run_cmd(cmd)
-    str_in(output+err, 'acme')
-    str_not_in(output+err, 'ERROR')
+        print('1. Adding files to HPSS')
+        cmd = 'zstash create {} --hpss={} zstash_test'.format(option, hpss_path)
+        output, err = run_cmd(cmd)
+        self.str_in(cmd, hpss_path, output+err, 'Transferring file to HPSS')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
 
+        #print('2. Testing chgrp')
+        #GROUP = 'acme'
+        #for option in ['-v', '']:
+        #    print('Running zstash chgrp {}'.format(option))
+        #    cmd = 'zstash chgrp {} -R {} {}'.format(option, GROUP, hpss_path)
+        #    output, err = run_cmd(cmd)
+        #    self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        #    print('Now check that the files are in the {} group'.format(GROUP))
+        #    cmd = 'hsi ls -l {}'.format(hpss_path)
+        #    output, err = run_cmd(cmd)
+        #    self.str_in(cmd, hpss_path, output+err, 'acme')
+        #    self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
 
-print('Running update on the newly created directory, nothing should happen')
-os.chdir('zstash_test')
-cmd = 'zstash update -v --hpss={}'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-os.chdir('../')
-str_in(output+err, 'Nothing to update')
-str_not_in(output+err, 'ERROR')
+        print('3. Running update on the newly created directory, nothing should happen')
+        os.chdir('zstash_test')
+        cmd = 'zstash update -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Nothing to update')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
 
+        print('4. Testing update with an actual change')
+        if not os.path.exists('zstash_test/dir2'):
+            os.mkdir('zstash_test/dir2')
+        write_file('zstash_test/dir2/file2.txt', 'file2 stuff')
+        write_file('zstash_test/dir/file1.txt', 'file1 stuff with changes')
 
-print('Testing update with an actual change')
-if not os.path.exists('zstash_test/dir2'):
-    os.mkdir('zstash_test/dir2')
-write_file('zstash_test/dir2/file2.txt', 'file2 stuff')
-write_file('zstash_test/dir/file1.txt', 'file1 stuff with changes')
+        os.chdir('zstash_test')
+        cmd = 'zstash update -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Transferring file to HPSS')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        # Make sure none of the old files are moved.
+        self.str_not_in(cmd, hpss_path, output+err, 'file0')
+        self.str_not_in(cmd, hpss_path, output+err, 'file_empty')
+        self.str_not_in(cmd, hpss_path, output+err, 'empty_dir')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
 
-os.chdir('zstash_test')
-cmd = 'zstash update -v --hpss={}'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-os.chdir('../')
-str_in(output+err, 'Transferring file to HPSS')
-str_not_in(output+err, 'ERROR')
-# Make sure none of the old files are moved.
-str_not_in(output+err, 'file0')
-str_not_in(output+err, 'file_empty')
-str_not_in(output+err, 'empty_dir')
-str_not_in(output+err, 'ERROR')
+        print('5. Adding many more files to the HPSS archive.')
+        msg = 'This is because we need many separate tar archives'
+        msg += ' for testing zstash extract/check with parallel.'
+        print(msg)
+        write_file('zstash_test/file3.txt', 'file3 stuff')
+        os.chdir('zstash_test')
+        cmd = 'zstash update --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        write_file('zstash_test/file4.txt', 'file4 stuff')
+        os.chdir('zstash_test')
+        cmd = 'zstash update --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        write_file('zstash_test/file5.txt', 'file5 stuff')
+        os.chdir('zstash_test')
+        cmd = 'zstash update --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
 
+        for option in ['', '-v', '-l']:
+            print('6. Testing zstash ls {}'.format(option))
+            cmd = 'zstash ls {} --hpss={}'.format(option, hpss_path)
+            output, err = run_cmd(cmd)
+            self.str_in(cmd, hpss_path, output+err, 'file0.txt')
+            self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
 
-print('Adding many more files to the HPSS archive.')
-msg = 'This is because we need many separate tar archives'
-msg += ' for testing zstash extract/check with parallel.'
-print(msg)
-write_file('zstash_test/file3.txt', 'file3 stuff')
-os.chdir('zstash_test')
-cmd = 'zstash update --hpss={}'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-os.chdir('../')
-write_file('zstash_test/file4.txt', 'file4 stuff')
-os.chdir('zstash_test')
-cmd = 'zstash update --hpss={}'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-os.chdir('../')
-write_file('zstash_test/file5.txt', 'file5 stuff')
-os.chdir('zstash_test')
-cmd = 'zstash update --hpss={}'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-os.chdir('../')
+        print('7. Testing the checking functionality')
+        cmd = 'zstash check --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        cmd = 'zstash check -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
 
+        print('8. Testing the extract functionality')
+        os.rename('zstash_test', 'zstash_test_backup')
+        os.mkdir('zstash_test')
+        os.chdir('zstash_test')
+        cmd = 'zstash extract --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting')
 
-for option in ['', '-v', '-l']:
-    print('Testing zstash ls {}'.format(option))
-    cmd = 'zstash ls {} --hpss={}'.format(option, HPSS_PATH)
-    output, err = run_cmd(cmd)
-    str_in(output+err, 'file0.txt')
-    str_not_in(output+err, 'ERROR')
-
-
-print('Testing the checking functionality')
-cmd = 'zstash check --hpss={}'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-str_in(output+err, 'Checking file0.txt')
-str_in(output+err, 'Checking file0_hard.txt')
-str_in(output+err, 'Checking file0_soft.txt')
-str_in(output+err, 'Checking file_empty.txt')
-str_in(output+err, 'Checking dir/file1.txt')
-str_in(output+err, 'Checking empty_dir')
-str_in(output+err, 'Checking dir2/file2.txt')
-str_in(output+err, 'Checking file3.txt')
-str_in(output+err, 'Checking file4.txt')
-str_in(output+err, 'Checking file5.txt')
-str_not_in(output+err, 'ERROR')
-cmd = 'zstash check -v --hpss={}'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-str_in(output+err, 'Checking file0.txt')
-str_in(output+err, 'Checking file0_hard.txt')
-str_in(output+err, 'Checking file0_soft.txt')
-str_in(output+err, 'Checking file_empty.txt')
-str_in(output+err, 'Checking dir/file1.txt')
-str_in(output+err, 'Checking empty_dir')
-str_in(output+err, 'Checking dir2/file2.txt')
-str_in(output+err, 'Checking file3.txt')
-str_in(output+err, 'Checking file4.txt')
-str_in(output+err, 'Checking file5.txt')
-str_not_in(output+err, 'ERROR')
-
-
-print('Testing the extract functionality')
-os.rename('zstash_test', 'zstash_test_backup')
-os.mkdir('zstash_test')
-os.chdir('zstash_test')
-cmd = 'zstash extract --hpss={}'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-os.chdir('../')
-str_in(output+err, 'Extracting file0.txt')
-str_in(output+err, 'Extracting file0_hard.txt')
-str_in(output+err, 'Extracting file0_soft.txt')
-str_in(output+err, 'Extracting file_empty.txt')
-str_in(output+err, 'Extracting dir/file1.txt')
-str_in(output+err, 'Extracting empty_dir')
-str_in(output+err, 'Extracting dir2/file2.txt')
-str_in(output+err, 'Extracting file3.txt')
-str_in(output+err, 'Extracting file4.txt')
-str_in(output+err, 'Extracting file5.txt')
-str_not_in(output+err, 'ERROR')
-str_not_in(output+err, 'Not extracting')
-
-print('Testing the extract functionality again, nothing should happen')
-os.chdir('zstash_test')
-cmd = 'zstash extract -v --hpss={}'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-# Check that the zstash/ directory is empty.
-# It should only contain an 'index.db'.
-if not compare(os.listdir('zstash'), ['index.db']):
-    print('*'*40)
-    print('The zstash directory should not have any tars.')
-    print('It has: {}'.format(os.listdir('zstash')))
-    print('*'*40)
-    stop()
-os.chdir('../')
-str_in(output+err, 'Not extracting file0.txt')
-str_in(output+err, 'Not extracting file0_hard.txt')
-# It's okay to extract the symlinks.
-str_not_in(output+err, 'Not extracting file0_soft.txt')
-str_in(output+err, 'Not extracting file_empty.txt')
-str_in(output+err, 'Not extracting dir/file1.txt')
-# It's okay to extract empty dirs.
-str_not_in(output+err, 'Not extracting empty_dir')
-str_in(output+err, 'Not extracting dir2/file2.txt')
-str_in(output+err, 'Not extracting file3.txt')
-str_in(output+err, 'Not extracting file4.txt')
-str_in(output+err, 'Not extracting file5.txt')
-str_not_in(output+err, 'ERROR')
-
-
-msg = 'Deleting the extracted files and doing it again, '
-msg += 'while making sure the tars are kept.'
-print(msg)
-shutil.rmtree('zstash_test')
-os.mkdir('zstash_test')
-os.chdir('zstash_test')
-cmd = 'zstash extract -v --hpss={} --keep'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-# Check that the zstash/ directory contains all expected files
-if not compare(os.listdir('zstash'), ['index.db', '000000.tar', '000001.tar', '000002.tar', '000003.tar', '000004.tar']):
-    print('*'*40)
-    print('The zstash directory does not contain expected files')
-    print('It has: {}'.format(os.listdir('zstash')))
-    print('*'*40)
-    stop()
-os.chdir('../')
-str_in(output+err, 'Transferring from HPSS')
-str_in(output+err, 'Extracting file0.txt')
-str_in(output+err, 'Extracting file0_hard.txt')
-str_in(output+err, 'Extracting file0_soft.txt')
-str_in(output+err, 'Extracting file_empty.txt')
-str_in(output+err, 'Extracting dir/file1.txt')
-str_in(output+err, 'Extracting empty_dir')
-str_in(output+err, 'Extracting dir2/file2.txt')
-str_in(output+err, 'Extracting file3.txt')
-str_in(output+err, 'Extracting file4.txt')
-str_in(output+err, 'Extracting file5.txt')
-str_not_in(output+err, 'ERROR')
-str_not_in(output+err, 'Not extracting')
-
-msg = 'Deleting the extracted files and doing it again without verbose option, '
-msg += 'while making sure the tars are kept.'
-print(msg)
-shutil.rmtree('zstash_test')
-os.mkdir('zstash_test')
-os.chdir('zstash_test')
-cmd = 'zstash extract --hpss={} --keep'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-# Check that the zstash/ directory contains all expected files
-if not compare(os.listdir('zstash'), ['index.db', '000000.tar', '000001.tar', '000002.tar', '000003.tar', '000004.tar']):
-    print('*'*40)
-    print('The zstash directory does not contain expected files')
-    print('It has: {}'.format(os.listdir('zstash')))
-    print('*'*40)
-    stop()
-os.chdir('../')
-str_in(output+err, 'Transferring from HPSS')
-str_in(output+err, 'Extracting file0.txt')
-str_in(output+err, 'Extracting file0_hard.txt')
-str_in(output+err, 'Extracting file0_soft.txt')
-str_in(output+err, 'Extracting file_empty.txt')
-str_in(output+err, 'Extracting dir/file1.txt')
-str_in(output+err, 'Extracting empty_dir')
-str_in(output+err, 'Extracting dir2/file2.txt')
-str_in(output+err, 'Extracting file3.txt')
-str_in(output+err, 'Extracting file4.txt')
-str_in(output+err, 'Extracting file5.txt')
-str_not_in(output+err, 'ERROR')
-str_not_in(output+err, 'Not extracting')
+        print('9. Testing the extract functionality again, nothing should happen')
+        os.chdir('zstash_test')
+        cmd = 'zstash extract -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        # Check that the zstash/ directory is empty.
+        # It should only contain an 'index.db'.
+        if not compare(os.listdir('zstash'), ['index.db']):
+            print('*'*40)
+            error_message = 'The zstash directory should not have any tars.\nIt has: {}'.format(
+                os.listdir('zstash'))
+            print(error_message)
+            print('*'*40)
+            self.stop(hpss_path, error_message)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file0_hard.txt')
+        # It's okay to extract the symlinks.
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting dir/file1.txt')
+        # It's okay to extract empty dirs.
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
 
 
-print('Deleting the extracted files and doing it again in parallel.')
-shutil.rmtree('zstash_test')
-os.mkdir('zstash_test')
-os.chdir('zstash_test')
-cmd = 'zstash extract -v --hpss={} --workers=3'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-os.chdir('../')
-str_in(output+err, 'Transferring from HPSS')
-str_in(output+err, 'Extracting file0.txt')
-str_in(output+err, 'Extracting file0_hard.txt')
-str_in(output+err, 'Extracting file0_soft.txt')
-str_in(output+err, 'Extracting file_empty.txt')
-str_in(output+err, 'Extracting dir/file1.txt')
-str_in(output+err, 'Extracting empty_dir')
-str_in(output+err, 'Extracting dir2/file2.txt')
-str_in(output+err, 'Extracting file3.txt')
-str_in(output+err, 'Extracting file4.txt')
-str_in(output+err, 'Extracting file5.txt')
-str_not_in(output+err, 'ERROR')
-str_not_in(output+err, 'Not extracting')
-# Checking that the printing was done in order.
-tar_order = []
-console_output = output+err
-for word in console_output.replace('\n', ' ').split(' '):
-    if '.tar' in word:
-        word = word.replace('zstash/', '')
-        tar_order.append(word)
-if tar_order != sorted(tar_order):
-    print('*'*40)
-    print('The tars were printed in this order: {}'.format(tar_order))
-    print('When it should have been in this order: {}'.format(sorted(tar_order)))
-    print('*'*40)
-    stop()
+        msg = 'Deleting the extracted files and doing it again, '
+        msg += 'while making sure the tars are kept.'
+        print(msg)
+        shutil.rmtree('zstash_test')
+        os.mkdir('zstash_test')
+        os.chdir('zstash_test')
+        cmd = 'zstash extract -v --hpss={} --keep'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        # Check that the zstash/ directory contains all expected files
+        if not compare(os.listdir('zstash'), ['index.db', '000000.tar', '000001.tar', '000002.tar', '000003.tar', '000004.tar']):
+            print('*'*40)
+            error_message = 'The zstash directory does not contain expected files.\nIt has: {}'.format(
+                os.listdir('zstash'))
+            print(error_message)
+            print('*'*40)
+            self.stop(hpss_path, error_message)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Transferring file from HPSS')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting')
 
-print('Deleting the extracted files and doing it again in parallel without verbose option.')
-shutil.rmtree('zstash_test')
-os.mkdir('zstash_test')
-os.chdir('zstash_test')
-cmd = 'zstash extract --hpss={} --workers=3'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-os.chdir('../')
-str_in(output+err, 'Transferring from HPSS')
-str_in(output+err, 'Extracting file0.txt')
-str_in(output+err, 'Extracting file0_hard.txt')
-str_in(output+err, 'Extracting file0_soft.txt')
-str_in(output+err, 'Extracting file_empty.txt')
-str_in(output+err, 'Extracting dir/file1.txt')
-str_in(output+err, 'Extracting empty_dir')
-str_in(output+err, 'Extracting dir2/file2.txt')
-str_in(output+err, 'Extracting file3.txt')
-str_in(output+err, 'Extracting file4.txt')
-str_in(output+err, 'Extracting file5.txt')
-str_not_in(output+err, 'ERROR')
-str_not_in(output+err, 'Not extracting')
-# Checking that the printing was done in order.
-tar_order = []
-console_output = output+err
-for word in console_output.replace('\n', ' ').split(' '):
-    if '.tar' in word:
-        word = word.replace('zstash/', '')
-        tar_order.append(word)
-if tar_order != sorted(tar_order):
-    print('*'*40)
-    print('The tars were printed in this order: {}'.format(tar_order))
-    print('When it should have been in this order: {}'.format(sorted(tar_order)))
-    print('*'*40)
-    stop()
+        msg = '10. Deleting the extracted files and doing it again without verbose option, '
+        msg += 'while making sure the tars are kept.'
+        print(msg)
+        shutil.rmtree('zstash_test')
+        os.mkdir('zstash_test')
+        os.chdir('zstash_test')
+        cmd = 'zstash extract --hpss={} --keep'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        # Check that the zstash/ directory contains all expected files
+        if not compare(os.listdir('zstash'), ['index.db', '000000.tar', '000001.tar', '000002.tar', '000003.tar', '000004.tar']):
+            print('*'*40)
+            error_message = 'The zstash directory does not contain expected files.\nIt has: {}'.format(
+                os.listdir('zstash'))
+            print(error_message)
+            print('*'*40)
+            self.stop(hpss_path, error_message)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Transferring file from HPSS')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting')
+
+        print('11. Deleting the extracted files and doing it again in parallel.')
+        shutil.rmtree('zstash_test')
+        os.mkdir('zstash_test')
+        os.chdir('zstash_test')
+        cmd = 'zstash extract -v --hpss={} --workers=3'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Transferring file from HPSS')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting')
+        # Checking that the printing was done in order.
+        tar_order = []
+        console_output = output+err
+        for word in console_output.replace('\n', ' ').split(' '):
+            if '.tar' in word:
+                word = word.replace('zstash/', '')
+                tar_order.append(word)
+        if tar_order != sorted(tar_order):
+            print('*'*40)
+            error_message = 'The tars were printed in this order: {}\nWhen it should have been in this order: {}'.format(
+                tar_order, sorted(tar_order))
+            print(error_message)
+            print('*'*40)
+            self.stop(hpss_path, error_message)
+
+        shutil.rmtree('zstash_test')
+        os.mkdir('zstash_test')
+        os.chdir('zstash_test')
+        cmd = 'zstash extract --hpss={} --workers=3'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Transferring file from HPSS')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting')
+        # Checking that the printing was done in order.
+        tar_order = []
+        console_output = output+err
+        for word in console_output.replace('\n', ' ').split(' '):
+            if '.tar' in word:
+                word = word.replace('zstash/', '')
+                tar_order.append(word)
+        if tar_order != sorted(tar_order):
+            print('*'*40)
+            error_message = 'The tars were printed in this order: {}\nWhen it should have been in this order: {}'.format(
+                tar_order, sorted(tar_order))
+            print(error_message)
+            print('*'*40)
+            self.stop(hpss_path, error_message)
+
+        print('12. Checking the files again in parallel.')
+        os.chdir('zstash_test')
+        cmd = 'zstash check -v --hpss={} --workers=3'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('13. Checking the files again in parallel without verbose option.')
+        os.chdir('zstash_test')
+        cmd = 'zstash check --hpss={} --workers=3'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('Causing MD5 mismatch errors and checking the files.')
+        os.chdir('zstash_test')
+        shutil.copy('zstash/index.db', 'zstash/index_old.db')
+        print('14. Messing up the MD5 of all of the files with an even id.')
+        cmd = ['sqlite3', 'zstash/index.db', 'UPDATE files SET md5 = 0 WHERE id % 2 = 0;']
+        run_cmd(cmd)
+        cmd = 'zstash check -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000001.tar')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000004.tar')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000002.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000000.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000003.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000005.tar')
+        # Put the original index.db back.
+        os.remove('zstash/index.db')
+        shutil.copy('zstash/index_old.db', 'zstash/index.db')
+        os.chdir('../')
+
+        print('Causing MD5 mismatch errors and checking the files in parallel.')
+        os.chdir('zstash_test')
+        shutil.copy('zstash/index.db', 'zstash/index_old.db')
+        print('15. Messing up the MD5 of all of the files with an even id.')
+        cmd = ['sqlite3', 'zstash/index.db', 'UPDATE files SET md5 = 0 WHERE id % 2 = 0;']
+        run_cmd(cmd)
+        cmd = 'zstash check -v --hpss={} --workers=3'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000001.tar')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000004.tar')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000002.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000000.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000003.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000005.tar')
+        # Put the original index.db back.
+        os.remove('zstash/index.db')
+        shutil.copy('zstash/index_old.db', 'zstash/index.db')
+        os.chdir('../')
+
+        print('Verifying the data from database with the actual files')
+        # Checksums from HPSS
+        cmd = ['sqlite3', 'zstash_test/zstash/index.db', 'SELECT md5, name FROM files;']
+        output_hpss, err_hpss = run_cmd(cmd)
+        hpss_dict = {}
+
+        for l in output_hpss.split('\n'):
+            l = l.split('|')
+            if len(l) >= 2:
+                f_name = l[1]
+                f_hash = l[0]
+                hpss_dict[f_name] = f_hash
+
+        # Checksums from local files
+        cmd = '''find zstash_test_backup -regex .*\.txt.* -exec md5sum {} + '''
+        output_local, err_local = run_cmd(cmd)
+        local_dict = {}
+
+        for l in output_local.split('\n'):
+            l = l.split('  ')
+            if len(l) >= 2:
+                f_name = l[1].split('/')  # remove the 'zstash_test_backup'
+                f_name = '/'.join(f_name[1:])
+                f_hash = l[0]
+                local_dict[f_name] = f_hash
+        print('filename|HPSS hash|local file hash')
+        for k in local_dict:
+            print('{}|{}|{}'.format(k, hpss_dict[k], local_dict[k]))
+
+        cleanup(hpss_path)
+
+    def testZstashWithoutHPSS(self):
+        print('*' * 40)
+        print('testZstashWithoutHPSS')
+        print('*' * 40)
+        print('0. Setup')
+        # No HPSS available.
+        hpss_path = 'none'
+        # Create files and directories
+        for option in ['-v', '']:
+            print('Creating files {}.'.format(option))
+            cleanup(hpss_path)
+            os.mkdir('zstash_test')
+            os.mkdir('zstash_test/empty_dir')
+            os.mkdir('zstash_test/dir')
+
+            write_file('zstash_test/file0.txt', 'file0 stuff')
+            write_file('zstash_test/file_empty.txt', '')
+            write_file('zstash_test/dir/file1.txt', 'file1 stuff')
+
+            if not os.path.lexists('zstash_test/file0_soft.txt'):
+                # If we symlink zstash_test/file0_soft.txt to zstash_test/file0.txt
+                # zstash_test/file0_soft.txt links to zstash_test/zstash_test/file0.txt
+                os.symlink('file0.txt', 'zstash_test/file0_soft.txt')
+
+            if not os.path.lexists('zstash_test/file0_soft_bad.txt'):
+                # If we symlink zstash_test/file0_soft.txt to zstash_test/file0.txt
+                # zstash_test/file0_soft.txt links to zstash_test/zstash_test/file0.txt
+                os.symlink('file0_that_doesnt_exist.txt', 'zstash_test/file0_soft_bad.txt')
+
+            if not os.path.lexists('zstash_test/file0_hard.txt'):
+                os.link('zstash_test/file0.txt', 'zstash_test/file0_hard.txt')
+
+        print('1. Adding files to HPSS')
+        cmd = 'zstash create {} --hpss={} zstash_test'.format(option, hpss_path)
+        output, err = run_cmd(cmd)
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        #print('2. Testing chgrp')
+        #GROUP = 'acme'
+        #for option in ['-v', '']:
+        #    print('Running zstash chgrp {}'.format(option))
+        #    cmd = 'zstash chgrp {} -R {} {}'.format(option, GROUP, hpss_path)
+        #    output, err = run_cmd(cmd)
+        #    self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        #    print('Now check that the files are in the {} group'.format(GROUP))
+        #    cmd = 'hsi ls -l {}'.format(hpss_path)
+        #    output, err = run_cmd(cmd)
+        #    self.str_in(cmd, hpss_path, output+err, 'acme')
+        #    self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('3. Running update on the newly created directory, nothing should happen')
+        os.chdir('zstash_test')
+        cmd = 'zstash update -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Nothing to update')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('4. Testing update with an actual change')
+        if not os.path.exists('zstash_test/dir2'):
+            os.mkdir('zstash_test/dir2')
+        write_file('zstash_test/dir2/file2.txt', 'file2 stuff')
+        write_file('zstash_test/dir/file1.txt', 'file1 stuff with changes')
+
+        os.chdir('zstash_test')
+        cmd = 'zstash update -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        # Make sure none of the old files are moved.
+        self.str_not_in(cmd, hpss_path, output+err, 'file0')
+        self.str_not_in(cmd, hpss_path, output+err, 'file_empty')
+        self.str_not_in(cmd, hpss_path, output+err, 'empty_dir')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('5. Adding many more files to the HPSS archive.')
+        msg = 'This is because we need many separate tar archives'
+        msg += ' for testing zstash extract/check with parallel.'
+        print(msg)
+        write_file('zstash_test/file3.txt', 'file3 stuff')
+        os.chdir('zstash_test')
+        cmd = 'zstash update --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        write_file('zstash_test/file4.txt', 'file4 stuff')
+        os.chdir('zstash_test')
+        cmd = 'zstash update --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        write_file('zstash_test/file5.txt', 'file5 stuff')
+        os.chdir('zstash_test')
+        cmd = 'zstash update --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+
+        print('Verifying the data from database with the actual files')
+        # Checksums from HPSS
+        cmd = ['sqlite3', 'zstash_test/zstash/index.db', 'SELECT md5, name FROM files;']
+        output_hpss, err_hpss = run_cmd(cmd)
+        hpss_dict = {}
+
+        for l in output_hpss.split('\n'):
+            l = l.split('|')
+            if len(l) >= 2:
+                f_name = l[1]
+                f_hash = l[0]
+                hpss_dict[f_name] = f_hash
+
+        # Checksums from local files
+        cmd = '''find zstash_test_backup -regex .*\.txt.* -exec md5sum {} + '''
+        output_local, err_local = run_cmd(cmd)
+        local_dict = {}
+
+        for l in output_local.split('\n'):
+            l = l.split('  ')
+            if len(l) >= 2:
+                f_name = l[1].split('/')  # remove the 'zstash_test_backup'
+                f_name = '/'.join(f_name[1:])
+                f_hash = l[0]
+                local_dict[f_name] = f_hash
+        print('filename|HPSS hash|local file hash')
+        for k in local_dict:
+            print('{}|{}|{}'.format(k, hpss_dict[k], local_dict[k]))
+
+        cleanup(hpss_path)
 
 
-print('Checking the files again in parallel.')
-os.chdir('zstash_test')
-cmd = 'zstash check -v --hpss={} --workers=3'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-os.chdir('../')
-str_in(output+err, 'Checking file0.txt')
-str_in(output+err, 'Checking file0_hard.txt')
-str_in(output+err, 'Checking file0_soft.txt')
-str_in(output+err, 'Checking file_empty.txt')
-str_in(output+err, 'Checking dir/file1.txt')
-str_in(output+err, 'Checking empty_dir')
-str_in(output+err, 'Checking dir2/file2.txt')
-str_in(output+err, 'Checking file3.txt')
-str_in(output+err, 'Checking file4.txt')
-str_in(output+err, 'Checking file5.txt')
-str_not_in(output+err, 'ERROR')
-
-print('Checking the files again in parallel without verbose option.')
-os.chdir('zstash_test')
-cmd = 'zstash check --hpss={} --workers=3'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-os.chdir('../')
-str_in(output+err, 'Checking file0.txt')
-str_in(output+err, 'Checking file0_hard.txt')
-str_in(output+err, 'Checking file0_soft.txt')
-str_in(output+err, 'Checking file_empty.txt')
-str_in(output+err, 'Checking dir/file1.txt')
-str_in(output+err, 'Checking empty_dir')
-str_in(output+err, 'Checking dir2/file2.txt')
-str_in(output+err, 'Checking file3.txt')
-str_in(output+err, 'Checking file4.txt')
-str_in(output+err, 'Checking file5.txt')
-str_not_in(output+err, 'ERROR')
-
-
-print('Causing MD5 mismatch errors and checking the files.')
-os.chdir('zstash_test')
-shutil.copy('zstash/index.db', 'zstash/index_old.db')
-print('Messing up the MD5 of all of the files with an even id.')
-cmd = ['sqlite3', 'zstash/index.db', 'UPDATE files SET md5 = 0 WHERE id % 2 = 0;']
-run_cmd(cmd)
-cmd = 'zstash check -v --hpss={}'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-str_in(output+err, 'md5 mismatch for: dir/file1.txt')
-str_in(output+err, 'md5 mismatch for: file3.txt')
-str_in(output+err, 'md5 mismatch for: file3.txt')
-str_in(output+err, 'ERROR: 000001.tar')
-str_in(output+err, 'ERROR: 000004.tar')
-str_in(output+err, 'ERROR: 000002.tar')
-str_not_in(output+err, 'ERROR: 000000.tar')
-str_not_in(output+err, 'ERROR: 000003.tar')
-str_not_in(output+err, 'ERROR: 000005.tar')
-# Put the original index.db back.
-os.remove('zstash/index.db')
-shutil.copy('zstash/index_old.db', 'zstash/index.db')
-os.chdir('../')
-
-
-print('Causing MD5 mismatch errors and checking the files in parallel.')
-os.chdir('zstash_test')
-shutil.copy('zstash/index.db', 'zstash/index_old.db')
-print('Messing up the MD5 of all of the files with an even id.')
-cmd = ['sqlite3', 'zstash/index.db', 'UPDATE files SET md5 = 0 WHERE id % 2 = 0;']
-run_cmd(cmd)
-cmd = 'zstash check -v --hpss={} --workers=3'.format(HPSS_PATH)
-output, err = run_cmd(cmd)
-str_in(output+err, 'md5 mismatch for: dir/file1.txt')
-str_in(output+err, 'md5 mismatch for: file3.txt')
-str_in(output+err, 'md5 mismatch for: file3.txt')
-str_in(output+err, 'ERROR: 000001.tar')
-str_in(output+err, 'ERROR: 000004.tar')
-str_in(output+err, 'ERROR: 000002.tar')
-str_not_in(output+err, 'ERROR: 000000.tar')
-str_not_in(output+err, 'ERROR: 000003.tar')
-str_not_in(output+err, 'ERROR: 000005.tar')
-# Put the original index.db back.
-os.remove('zstash/index.db')
-shutil.copy('zstash/index_old.db', 'zstash/index.db')
-os.chdir('../')
-
-
-print('Verifying the data from database with the actual files')
-# Checksums from HPSS
-cmd = ['sqlite3', 'zstash_test/zstash/index.db', 'SELECT md5, name FROM files;']
-output_hpss, err_hpss = run_cmd(cmd)
-hpss_dict = {}
-
-for l in output_hpss.split('\n'):
-    l = l.split('|')
-    if len(l) >= 2:
-        f_name = l[1]
-        f_hash = l[0]
-        hpss_dict[f_name] = f_hash
-
-# Checksums from local files
-cmd = '''find zstash_test_backup -regex .*\.txt.* -exec md5sum {} + '''
-output_local, err_local = run_cmd(cmd)
-local_dict = {}
-
-for l in output_local.split('\n'):
-    l = l.split('  ')
-    if len(l) >= 2:
-        f_name = l[1].split('/')  # remove the 'zstash_test_backup'
-        f_name = '/'.join(f_name[1:])
-        f_hash = l[0]
-        local_dict[f_name] = f_hash
-print('filename|HPSS hash|local file hash')
-for k in local_dict:
-    print('{}|{}|{}'.format(k, hpss_dict[k], local_dict[k]))
-
-
-cleanup()
-print('*'*40)
-print('All of the tests passed! :)')
-print('*'*40)
+if __name__ == '__main__':
+    unittest.main()

--- a/zstash/hpss.py
+++ b/zstash/hpss.py
@@ -2,88 +2,81 @@ from __future__ import print_function, absolute_import
 
 import os.path
 import shlex
-from subprocess import Popen, PIPE
+import subprocess
 from .settings import logger
+
+
+def run_command(command, error_str):
+    p1 = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    (stdout, stderr) = p1.communicate()
+    status = p1.returncode
+    if status != 0:
+        logger.error(error_str)
+        logger.debug('stdout:\n%s', stdout)
+        logger.debug('stderr:\n%s', stderr)
+        raise Exception
+
+
+def hpss_transfer(hpss, file_path, transfer_type, keep=None):
+    if hpss == 'none':
+        return
+    if transfer_type == 'put':
+        transfer_word = 'to'
+        transfer_command = 'put'
+    elif transfer_type == 'get':
+        transfer_word = 'from'
+        transfer_command = 'get'
+    else:
+        raise Exception('Invalid transfer_type={}'.format(transfer_type))
+    logger.info('Transferring file {} HPSS: {}'.format(transfer_word, file_path))
+    path, name = os.path.split(file_path)
+
+    # Need to be in local directory for hsi put to work
+    cwd = os.getcwd()
+    if path != '':
+        if (transfer_type == 'get') and (not os.path.isdir(path)):
+            os.makedirs(path)
+        os.chdir(path)
+
+    # Transfer file using hsi put
+    command = 'hsi -q "cd {}; {} {}"'.format(hpss, transfer_command, name)
+    error_str = 'Transferring file {} HPSS: {}'.format(transfer_word, name)
+    run_command(command, error_str)
+
+    # Back to original working directory
+    if path != '':
+        os.chdir(cwd)
+
+    if transfer_type == 'put':
+        # Remove local file if requested
+        if not keep:
+            os.remove(file_path)
 
 
 def hpss_put(hpss, file, keep=True):
     """
     Put a file to the HPSS archive.
     """
-
-    logger.info('Transferring file to HPSS: %s' % (file))
-    path, name = os.path.split(file)
-
-    # Need to be in local directory for hsi put to work
-    cwd = os.getcwd()
-    if path != '':
-        os.chdir(path)
-
-    # Transfer file using hsi put
-    cmd = 'hsi -q "cd %s; put %s"' % (hpss, name)
-    p1 = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
-    (stdout, stderr) = p1.communicate()
-    status = p1.returncode
-    if status != 0:
-        logger.error('Transferring file to HPSS: %s' % (name))
-        logger.debug('stdout:\n%s', stdout)
-        logger.debug('stderr:\n%s', stderr)
-        raise Exception
-
-    # Back to original working directory
-    if path != '':
-        os.chdir(cwd)
-
-    # Remove local file if requested
-    if not keep:
-        os.remove(file)
+    hpss_transfer(hpss, file, 'put', keep)
 
 
 def hpss_get(hpss, file):
     """
-    Get ia file from the HPSS archive.
+    Get a file from the HPSS archive.
     """
+    hpss_transfer(hpss, file, 'get', False)
 
-    logger.info('Transferring from HPSS: %s' % (file))
-    path, name = os.path.split(file)
-
-    # Need to be in local directory for hsi get to work
-    cwd = os.getcwd()
-    if path != '':
-        if not os.path.isdir(path):
-            os.makedirs(path)
-        os.chdir(path)
-
-    # Transfer file using hsi get
-    cmd = 'hsi -q "cd %s; get %s"' % (hpss, name)
-    p1 = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
-    (stdout, stderr) = p1.communicate()
-    status = p1.returncode
-    if status != 0:
-        logger.error('Transferring file from HPSS: %s' % (name))
-        logger.debug('stdout:\n%s', stdout)
-        logger.debug('stderr:\n%s', stderr)
-        raise Exception
-
-    # Back to original working directory
-    if path != '':
-        os.chdir(cwd)
 
 def hpss_chgrp(hpss, group, recurse=False):
     """
     Change the group of the HPSS archive.
     """
+    if hpss == 'none':
+        return
     if recurse:
-        cmd = 'hsi chgrp -R {} {}'.format(group, hpss)
+        recurse_str = '-R '
     else:
-        cmd = 'hsi chgrp {} {}'.format(group, hpss)
-
-    p1 = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE)
-    (stdout, stderr) = p1.communicate()
-    status = p1.returncode
-    if status != 0:
-        logger.error('Changing group of HPSS archive {} to {}'.format(hpss, group))
-        logger.debug('stdout:\n%s', stdout)
-        logger.debug('stderr:\n%s', stderr)
-        raise Exception
-
+        recurse_str = ''
+    command = 'hsi chgrp {}{} {}'.format(recurse_str, group, hpss)
+    error_str = 'Changing group of HPSS archive {} to {}'.format(hpss, group)
+    run_command(command, error_str)


### PR DESCRIPTION
In zstash/hpss.py:
- Factor out common code into helper functions.
- Add option to not use HPSS (thus completing step 1 of 2 in #21)

In tests/test.py:
- Refactor test code to use `unittest`.
- Add test for when `hpss='none'`.