### PR TITLE
Option for unavailable HPSS

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -44,14 +44,12 @@ def cleanup(hpss_path):
     After the script has failed/run, remove all created files, even those on the HPSS repo.
     """
     print('Removing test files, both locally and at the HPSS repo')
-    if os.path.exists('zstash_test'):
-        shutil.rmtree('zstash_test')
-    if os.path.exists('zstash_test_backup'):
-        shutil.rmtree('zstash_test_backup')
-    if os.path.exists('zstash'):
-        shutil.rmtree('zstash')
-    cmd = 'hsi rm -R {}'.format(hpss_path)
-    run_cmd(cmd)
+    for d in ['zstash_test', 'zstash_test_backup', 'zstash']:
+        if os.path.exists(d):
+            shutil.rmtree(d)
+    if hpss_path and hpss_path.lower() != 'none':
+        cmd = 'hsi rm -R {}'.format(hpss_path)
+        run_cmd(cmd)
 
 
 # Compare content of two (unordered lists)
@@ -60,7 +58,7 @@ def compare(s, t):
     return Counter(s) == Counter(t)
 
 
-class TestZStash(unittest.TestCase):
+class TestZstash(unittest.TestCase):
     def stop(self, hpss_path, error_message):
         """
         Cleanup and stop running this script.
@@ -90,6 +88,7 @@ class TestZStash(unittest.TestCase):
             print('*' * 40)
             self.stop(hpss_path, error_message)
 
+    @unittest.skipIf(os.system('which hsi') != 0, 'This system does not have hsi')
     def testZstashWithHPSS(self):
         print('*' * 40)
         print('testZstashWithHPSS')
@@ -511,6 +510,457 @@ class TestZStash(unittest.TestCase):
             print('{}|{}|{}'.format(k, hpss_dict[k], local_dict[k]))
 
         cleanup(hpss_path)
+
+    def testZstashWithoutHPSS(self):
+        self.helperZstashWithoutHPSS('testZstashWithoutHPSS', 'none')
+
+    def testZstashNoneHPSS(self):
+        self.helperZstashWithoutHPSS('testZstashNoneHPSS', 'None')
+
+    def helperZstashWithoutHPSS(self, test_name, hpss_path):
+        print('*' * 40)
+        print(test_name)
+        print('*' * 40)
+        print('0. Setup')
+        # Create files and directories
+        for option in ['-v', '']:
+            print('Creating files {}.'.format(option))
+            cleanup(hpss_path)
+            os.mkdir('zstash_test')
+            os.mkdir('zstash_test/empty_dir')
+            os.mkdir('zstash_test/dir')
+
+            write_file('zstash_test/file0.txt', 'file0 stuff')
+            write_file('zstash_test/file_empty.txt', '')
+            write_file('zstash_test/dir/file1.txt', 'file1 stuff')
+
+            if not os.path.lexists('zstash_test/file0_soft.txt'):
+                # If we symlink zstash_test/file0_soft.txt to zstash_test/file0.txt
+                # zstash_test/file0_soft.txt links to zstash_test/zstash_test/file0.txt
+                os.symlink('file0.txt', 'zstash_test/file0_soft.txt')
+
+            if not os.path.lexists('zstash_test/file0_soft_bad.txt'):
+                # If we symlink zstash_test/file0_soft.txt to zstash_test/file0.txt
+                # zstash_test/file0_soft.txt links to zstash_test/zstash_test/file0.txt
+                os.symlink('file0_that_doesnt_exist.txt', 'zstash_test/file0_soft_bad.txt')
+
+            if not os.path.lexists('zstash_test/file0_hard.txt'):
+                os.link('zstash_test/file0.txt', 'zstash_test/file0_hard.txt')
+
+        print('1. Adding files to HPSS replacement')
+        cmd = 'zstash create {} --hpss={} zstash_test'.format(option, hpss_path)
+        output, err = run_cmd(cmd)
+        self.str_in(cmd, hpss_path, output+err, 'put: HPSS is unavailable')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        print(os.listdir())
+
+        print('2. Testing chgrp')
+        GROUP = 'acme'
+        for option in ['-v', '']:
+            print('Running zstash chgrp {}'.format(option))
+            cmd = 'zstash chgrp {} -R {} {}'.format(option, GROUP, hpss_path)
+            output, err = run_cmd(cmd)
+            self.str_in(cmd, hpss_path, output+err, 'chgrp: HPSS is unavailable')
+            self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('3. Running update on the newly created directory, nothing should happen')
+        os.chdir('zstash_test')
+        cmd = 'zstash update -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Nothing to update')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('4. Testing update with an actual change')
+        if not os.path.exists('zstash_test/dir2'):
+            os.mkdir('zstash_test/dir2')
+        write_file('zstash_test/dir2/file2.txt', 'file2 stuff')
+        write_file('zstash_test/dir/file1.txt', 'file1 stuff with changes')
+
+        os.chdir('zstash_test')
+        cmd = 'zstash update -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'put: HPSS is unavailable')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        # Make sure none of the old files are moved.
+        self.str_not_in(cmd, hpss_path, output+err, 'file0')
+        self.str_not_in(cmd, hpss_path, output+err, 'file_empty')
+        self.str_not_in(cmd, hpss_path, output+err, 'empty_dir')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('5. Adding many more files to the HPSS archive.')
+        msg = 'This is because we need many separate tar archives'
+        msg += ' for testing zstash extract/check with parallel.'
+        print(msg)
+        write_file('zstash_test/file3.txt', 'file3 stuff')
+        os.chdir('zstash_test')
+        cmd = 'zstash update --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        write_file('zstash_test/file4.txt', 'file4 stuff')
+        os.chdir('zstash_test')
+        cmd = 'zstash update --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        write_file('zstash_test/file5.txt', 'file5 stuff')
+        os.chdir('zstash_test')
+        cmd = 'zstash update --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        print(os.getcwd())
+
+        os.chdir('zstash_test')
+        for option in ['', '-v', '-l']:
+            print('6. Testing zstash ls {}'.format(option))
+            cmd = 'zstash ls {} --hpss={}'.format(option, hpss_path)
+            output, err = run_cmd(cmd)
+            self.str_in(cmd, hpss_path, output+err, 'file0.txt')
+            self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('7. Testing the checking functionality')
+        cmd = 'zstash check --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        cmd = 'zstash check -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('8. Testing the extract functionality')
+        os.chdir('../')
+        os.rename('zstash_test', 'zstash_test_backup')
+        os.mkdir('zstash_test')
+        os.chdir('zstash_test')
+        shutil.copytree('../zstash_test_backup/zstash', 'zstash')
+        cmd = 'zstash extract --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('9. Testing the extract functionality again, nothing should happen')
+        os.chdir('zstash_test')
+        cmd = 'zstash extract -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file0_hard.txt')
+        # It's okay to extract the symlinks.
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting dir/file1.txt')
+        # It's okay to extract empty dirs.
+        #self.str_not_in(cmd, hpss_path, output+err, 'Not extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Not extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+
+        msg = 'Deleting the extracted files and doing it again, '
+        msg += 'while making sure the tars are kept.'
+        print(msg)
+        shutil.rmtree('zstash_test')
+        os.mkdir('zstash_test')
+        os.chdir('zstash_test')
+        shutil.copytree('../zstash_test_backup/zstash', 'zstash')
+        cmd = 'zstash extract -v --hpss={} --keep'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        # Check that the zstash/ directory contains all expected files
+        if not compare(os.listdir('zstash'), ['index.db', '000000.tar', '000001.tar', '000002.tar', '000003.tar', '000004.tar']):
+            print('*'*40)
+            error_message = 'The zstash directory does not contain expected files.\nIt has: {}'.format(
+                os.listdir('zstash'))
+            print(error_message)
+            print('*'*40)
+            self.stop(hpss_path, error_message)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting')
+
+        msg = '10. Deleting the extracted files and doing it again without verbose option, '
+        msg += 'while making sure the tars are kept.'
+        print(msg)
+        shutil.rmtree('zstash_test')
+        os.mkdir('zstash_test')
+        os.chdir('zstash_test')
+        shutil.copytree('../zstash_test_backup/zstash', 'zstash')
+        cmd = 'zstash extract --hpss={} --keep'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        # Check that the zstash/ directory contains all expected files
+        if not compare(os.listdir('zstash'), ['index.db', '000000.tar', '000001.tar', '000002.tar', '000003.tar', '000004.tar']):
+            print('*'*40)
+            error_message = 'The zstash directory does not contain expected files.\nIt has: {}'.format(
+                os.listdir('zstash'))
+            print(error_message)
+            print('*'*40)
+            self.stop(hpss_path, error_message)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting')
+
+        print('11. Deleting the extracted files and doing it again in parallel.')
+        shutil.rmtree('zstash_test')
+        os.mkdir('zstash_test')
+        os.chdir('zstash_test')
+        shutil.copytree('../zstash_test_backup/zstash', 'zstash')
+        cmd = 'zstash extract -v --hpss={} --workers=3'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting')
+        # Checking that the printing was done in order.
+        tar_order = []
+        console_output = output+err
+        for word in console_output.replace('\n', ' ').split(' '):
+            if '.tar' in word:
+                word = word.replace('zstash/', '')
+                tar_order.append(word)
+        if tar_order != sorted(tar_order):
+            print('*'*40)
+            error_message = 'The tars were printed in this order: {}\nWhen it should have been in this order: {}'.format(
+                tar_order, sorted(tar_order))
+            print(error_message)
+            print('*'*40)
+            self.stop(hpss_path, error_message)
+
+        shutil.rmtree('zstash_test')
+        os.mkdir('zstash_test')
+        os.chdir('zstash_test')
+        shutil.copytree('../zstash_test_backup/zstash', 'zstash')
+        cmd = 'zstash extract --hpss={} --workers=3'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Extracting file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+        self.str_not_in(cmd, hpss_path, output+err, 'Not extracting')
+        # Checking that the printing was done in order.
+        tar_order = []
+        console_output = output+err
+        for word in console_output.replace('\n', ' ').split(' '):
+            if '.tar' in word:
+                word = word.replace('zstash/', '')
+                tar_order.append(word)
+        if tar_order != sorted(tar_order):
+            print('*'*40)
+            error_message = 'The tars were printed in this order: {}\nWhen it should have been in this order: {}'.format(
+                tar_order, sorted(tar_order))
+            print(error_message)
+            print('*'*40)
+            self.stop(hpss_path, error_message)
+
+        print('12. Checking the files again in parallel.')
+        os.chdir('zstash_test')
+        cmd = 'zstash check -v --hpss={} --workers=3'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('13. Checking the files again in parallel without verbose option.')
+        os.chdir('zstash_test')
+        cmd = 'zstash check --hpss={} --workers=3'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        os.chdir('../')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_hard.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file0_soft.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file_empty.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking empty_dir')
+        self.str_in(cmd, hpss_path, output+err, 'Checking dir2/file2.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file4.txt')
+        self.str_in(cmd, hpss_path, output+err, 'Checking file5.txt')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR')
+
+        print('Causing MD5 mismatch errors and checking the files.')
+        os.chdir('zstash_test')
+        shutil.copy('zstash/index.db', 'zstash/index_old.db')
+        print('14. Messing up the MD5 of all of the files with an even id.')
+        cmd = ['sqlite3', 'zstash/index.db', 'UPDATE files SET md5 = 0 WHERE id % 2 = 0;']
+        run_cmd(cmd)
+        cmd = 'zstash check -v --hpss={}'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000001.tar')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000004.tar')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000002.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000000.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000003.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000005.tar')
+        # Put the original index.db back.
+        os.remove('zstash/index.db')
+        shutil.copy('zstash/index_old.db', 'zstash/index.db')
+        os.chdir('../')
+
+        print('Causing MD5 mismatch errors and checking the files in parallel.')
+        os.chdir('zstash_test')
+        shutil.copy('zstash/index.db', 'zstash/index_old.db')
+        print('15. Messing up the MD5 of all of the files with an even id.')
+        cmd = ['sqlite3', 'zstash/index.db', 'UPDATE files SET md5 = 0 WHERE id % 2 = 0;']
+        run_cmd(cmd)
+        cmd = 'zstash check -v --hpss={} --workers=3'.format(hpss_path)
+        output, err = run_cmd(cmd)
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: dir/file1.txt')
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'md5 mismatch for: file3.txt')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000001.tar')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000004.tar')
+        self.str_in(cmd, hpss_path, output+err, 'ERROR: 000002.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000000.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000003.tar')
+        self.str_not_in(cmd, hpss_path, output+err, 'ERROR: 000005.tar')
+        # Put the original index.db back.
+        os.remove('zstash/index.db')
+        shutil.copy('zstash/index_old.db', 'zstash/index.db')
+        os.chdir('../')
+
+        print('Verifying the data from database with the actual files')
+        # Checksums from HPSS
+        cmd = ['sqlite3', 'zstash_test/zstash/index.db', 'SELECT md5, name FROM files;']
+        output_hpss, err_hpss = run_cmd(cmd)
+        hpss_dict = {}
+
+        for l in output_hpss.split('\n'):
+            l = l.split('|')
+            if len(l) >= 2:
+                f_name = l[1]
+                f_hash = l[0]
+                hpss_dict[f_name] = f_hash
+
+        # Checksums from local files
+        cmd = '''find zstash_test_backup -regex .*\.txt.* -exec md5sum {} + '''
+        output_local, err_local = run_cmd(cmd)
+        local_dict = {}
+
+        for l in output_local.split('\n'):
+            l = l.split('  ')
+            if len(l) >= 2:
+                f_name = l[1].split('/')  # remove the 'zstash_test_backup'
+                f_name = '/'.join(f_name[1:])
+                f_hash = l[0]
+                local_dict[f_name] = f_hash
+        print('filename|HPSS hash|local file hash')
+        for k in local_dict:
+            print('{}|{}|{}'.format(k, hpss_dict[k], local_dict[k]))
+        
+        cleanup(hpss_path)
+
+    def testKeepTars(self):
+        print('*' * 40)
+        print('testKeepTars')
+        print('*' * 40)
+        if os.path.exists('test_files'):
+            shutil.rmtree('test_files')
+        os.mkdir('test_files')
+        run_cmd('touch test_files/file1.txt')
+        run_cmd('touch test_files/file2.txt')
+        hpss_path = 'none'
+        # Run `zstash create`
+        run_cmd('zstash create --hpss={} test_files'.format(hpss_path))
+        actual = sorted(os.listdir('test_files/zstash/'))
+        expected = sorted(['000000.tar', 'index.db'])
+        self.assertEqual(actual, expected)
+        os.chdir('test_files')
+        # Delete txt files
+        run_cmd('rm file1.txt file2.txt')
+        # Run `zstash extract`
+        output, err = run_cmd('zstash extract --hpss={}'.format(hpss_path))
+        # Run `zstash check`
+        output, err = run_cmd('zstash check --hpss={}'.format(hpss_path))
+        self.assertEqual(output+err, 'INFO: Opening tar archive zstash/000000.tar\nINFO: Checking file1.txt\nINFO: Checking file2.txt\nINFO: No failures detected when checking the files.\n')
+        # Check that tar and db files were not deleted
+        actual = sorted(os.listdir('zstash/'))
+        expected = sorted(['000000.tar', 'index.db'])
+        self.assertEqual(actual, expected)
+        # Check that tar file is read-only
+        # https://stackoverflow.com/questions/1861836/checking-file-permissions-in-linux-with-python
+        stat = os.stat('zstash/000000.tar')
+        oct_mode = str(oct(stat.st_mode))[-3:]
+        self.assertEqual(oct_mode, '440')
+        os.chdir('..')
+        shutil.rmtree('test_files')
 
 
 if __name__ == '__main__':

--- a/zstash/chgrp.py
+++ b/zstash/chgrp.py
@@ -19,6 +19,9 @@ def chgrp():
                         help="increase output verbosity")
 
     args = parser.parse_args(sys.argv[2:])
+    if args.hpss and args.hpss.lower() == 'none':
+        args.hpss = 'none'
+    
     if args.verbose: logger.setLevel(logging.DEBUG)
     recurse = True if args.R else False
     hpss_chgrp(args.hpss, args.group, recurse)

--- a/zstash/extract.py
+++ b/zstash/extract.py
@@ -107,6 +107,8 @@ def extract(keep_files=True):
                           help="increase output verbosity")
     parser.add_argument('files', nargs='*', default=['*'])
     args = parser.parse_args(sys.argv[2:])
+    if args.hpss and args.hpss.lower() == 'none':
+        args.hpss = 'none'
     # Note: setting logging level to anything other than DEBUG doesn't work with 
     # multiple workers. This must have someting to do with the custom logger 
     # implemented for multiple workers.
@@ -139,7 +141,11 @@ def extract(keep_files=True):
     config.keep = bool(int(config.keep))
 
     # The command line arg should always have precedence
-    config.keep = args.keep
+    if args.hpss == 'none':
+        # If no HPSS is available, always keep the files.
+        config.keep = True
+    else:
+        config.keep = args.keep
     if args.hpss is not None:
         config.hpss = args.hpss
 
@@ -384,7 +390,7 @@ def extractFiles(files, keep_files, keep_tars, multiprocess_worker=None):
 
             # Open new archive next time
             newtar = True
-
+            
             # Delete this tar if the corresponding command-line arg was used.
             if not keep_tars:
                 os.remove(tfname)

--- a/zstash/ls.py
+++ b/zstash/ls.py
@@ -26,6 +26,8 @@ def ls():
     
     parser.add_argument('files', nargs='*', default=['*'])
     args = parser.parse_args(sys.argv[2:])
+    if args.hpss and args.hpss.lower() == 'none':
+        args.hpss = 'none'
     if args.verbose: logger.setLevel(logging.DEBUG)
 
     # Open database

--- a/zstash/update.py
+++ b/zstash/update.py
@@ -35,6 +35,8 @@ def update():
     optional.add_argument('-v', '--verbose', action="store_true", 
                           help="increase output verbosity")
     args = parser.parse_args(sys.argv[2:])
+    if args.hpss and args.hpss.lower() == 'none':
+        args.hpss = 'none'
     if args.verbose: logger.setLevel(logging.DEBUG)
 
     # Open database
@@ -63,7 +65,11 @@ def update():
     config.keep = bool(int(config.keep))
 
     # The command line arg should always have precedence
-    config.keep = args.keep
+    if args.hpss == 'none':
+        # If no HPSS is available, always keep the files.
+        config.keep = True
+    else:
+        config.keep = args.keep
     if args.hpss is not None:
         config.hpss = args.hpss
 


### PR DESCRIPTION
Add functionality to allow Zstash to function on systems without HPSS.

Completes step 1 of 2 in #21, in addition to being the second and last pull request to replace #39.

Checklist of issues mentioned in #39:
- [x] `zstash check hpss=none` should NOT delete tar files.
- [x] When using `hpss=none` make the tar files read-only
- [x] Add test to check  that `zstash check hpss=none` does NOT delete tar files.
- [x] Remove all `hsi` operations from the non-HPSS tests
- [x] On non-HPSS systems, only run the non-HPSS tests
- [x] Fix `No such file or directory` error from `find zstash_test_backup -regex .*\.txt.* -exec md5sum {}`
- [x] Fix `chgrp` test
- [ ] Increment version number (this will be done after merging this pull request)