### PR TITLE
Add a conda build config for py 3.6, 3.7 and 3.8

### DIFF
--- a/conda/conda_build_config.yaml
+++ b/conda/conda_build_config.yaml
@@ -1,0 +1,10 @@
+python:
+  - 3.6
+  - 3.7
+  - 3.8
+
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -11,11 +11,11 @@ build:
 
 requirements:
   build:
-    - python 3
+    - python >=3.6
     - setuptools
 
   run:
-    - python 3
+    - python >=3.6
 
 about:
     home: https://github.com/E3SM-Project/zstash


### PR DESCRIPTION
This will make it easier to build all supported python versions in one go.