### PR TITLE
Add checksums for tar files

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -232,7 +232,15 @@ class TestZstash(unittest.TestCase):
             )
         return use_hpss
 
-    def create(self, use_hpss, zstash_path, keep=False, cache=None, verbose=False):
+    def create(
+        self,
+        use_hpss,
+        zstash_path,
+        keep=False,
+        cache=None,
+        verbose=False,
+        no_tars_md5=False,
+    ):
         """
         Run `zstash create`.
         """
@@ -248,11 +256,13 @@ class TestZstash(unittest.TestCase):
         else:
             cache_option = ""
         v_option = " -v" if verbose else ""
-        cmd = "{}zstash create{}{}{} --hpss={} {}".format(
+        no_tars_md5_option = " --no_tars_md5" if no_tars_md5 else ""
+        cmd = "{}zstash create{}{}{}{} --hpss={} {}".format(
             zstash_path,
             keep_option,
             cache_option,
             v_option,
+            no_tars_md5_option,
             self.hpss_path,
             self.test_dir,
         )

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -13,11 +13,12 @@ from tests.base import (
 
 class TestLs(TestZstash):
     # x = on, no mark = off, b = both on and off tested
-    # option | Ls |
-    # --hpss  |x|
-    # --cache |b|
-    # -l      |b|
-    # -v      |b|
+    # option  | Ls | LsTars |
+    # --hpss  |x|x|
+    # --cache |b| |
+    # --tars  | |b|
+    # -l      |b|b|
+    # -v      |b| |
 
     def helperLs(self, test_name, hpss_path, cache=None, zstash_path=ZSTASH_PATH):
         """
@@ -43,6 +44,73 @@ class TestLs(TestZstash):
             self.check_strings(cmd, output + err, ["file0.txt"], ["ERROR"])
         os.chdir(TOP_LEVEL)
 
+    def helperLsTars(self, test_name, hpss_path, zstash_path=ZSTASH_PATH):
+        """
+        Test `zstash ls --tars`
+        """
+        self.hpss_path = hpss_path
+        use_hpss = self.setupDirs(test_name)
+        self.create(use_hpss, zstash_path)
+        self.assertWorkspace()
+        os.chdir(self.test_dir)
+
+        print_starred("Testing zstash ls --tars")
+        cmd = "{}zstash ls --tars --hpss={}".format(zstash_path, self.hpss_path)
+        output, err = run_cmd(cmd)
+        self.check_strings(cmd, output + err, ["000000.tar"], ["ERROR"])
+
+        print_starred("Testing zstash ls --tars -l")
+        cmd = "{}zstash ls --tars -l --hpss={}".format(zstash_path, self.hpss_path)
+        output, err = run_cmd(cmd)
+        self.check_strings(cmd, output + err, ["000000.tar"], ["ERROR"])
+
+        os.chdir(TOP_LEVEL)
+
+    def helperLsTarsUpdate(self, test_name, hpss_path, zstash_path=ZSTASH_PATH):
+        """
+        Test `zstash ls --tars` when the database was initially created without the tars table
+        """
+        self.hpss_path = hpss_path
+        use_hpss = self.setupDirs(test_name)
+        # Create without a tar table -- simulate a user updating an existing database
+        self.create(use_hpss, zstash_path, no_tars_md5=True)
+        self.assertWorkspace()
+        os.chdir(self.test_dir)
+
+        print_starred("Testing zstash ls")
+        cmd = "{}zstash ls --hpss={}".format(zstash_path, self.hpss_path)
+        output, err = run_cmd(cmd)
+        # tars should not be listed
+        self.check_strings(
+            cmd, output + err, [], ["tars table does not exist", ".tar", "ERROR"]
+        )
+
+        print_starred("Testing zstash ls --tars")
+        cmd = "{}zstash ls --tars --hpss={}".format(zstash_path, self.hpss_path)
+        output, err = run_cmd(cmd)
+        # tars should not be listed
+        self.check_strings(
+            cmd, output + err, ["tars table does not exist"], [".tar", "ERROR"]
+        )
+
+        os.chdir(TOP_LEVEL)
+        # Updating should create the tars table
+        self.add_files(use_hpss, zstash_path)
+        os.chdir(self.test_dir)
+
+        print_starred("Testing zstash ls --tars")
+        cmd = "{}zstash ls --tars --hpss={}".format(zstash_path, self.hpss_path)
+        output, err = run_cmd(cmd)
+        # tar should be listed now
+        self.check_strings(cmd, output + err, ["000001.tar"], ["ERROR"])
+
+        print_starred("Testing zstash ls --tars -l")
+        cmd = "{}zstash ls --tars -l --hpss={}".format(zstash_path, self.hpss_path)
+        output, err = run_cmd(cmd)
+        self.check_strings(cmd, output + err, ["000001.tar"], ["ERROR"])
+
+        os.chdir(TOP_LEVEL)
+
     def testLs(self):
         self.helperLs("testLs", "none")
 
@@ -60,6 +128,20 @@ class TestLs(TestZstash):
     def testLsCacheHPSS(self):
         self.conditional_hpss_skip()
         self.helperLs("testLsCacheHPSS", HPSS_ARCHIVE, cache="my_cache")
+
+    def testLsTars(self):
+        self.helperLsTars("testLsTars", "none")
+
+    def testLsTarsHPSS(self):
+        self.conditional_hpss_skip()
+        self.helperLsTars("testLsTarsHPSS", HPSS_ARCHIVE)
+
+    def testLsTarsUpdate(self):
+        self.helperLsTarsUpdate("testLsTarsUpdate", "none")
+
+    def testLsTarsUpdateHPSS(self):
+        self.conditional_hpss_skip()
+        self.helperLsTarsUpdate("testLsTarsUpdateHPSS", HPSS_ARCHIVE)
 
 
 if __name__ == "__main__":

--- a/zstash/extract.py
+++ b/zstash/extract.py
@@ -337,7 +337,7 @@ def extractFiles(  # noqa: C901
     the contents of what's in its print queue.
     """
     failures: List[FilesRow] = []
-    tfname: Optional[str] = None
+    tfname: str
     newtar: bool = True
     nfiles: int = len(files)
     if multiprocess_worker:

--- a/zstash/settings.py
+++ b/zstash/settings.py
@@ -37,11 +37,13 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 # Type aliases
 TupleFilesRow = Tuple[int, str, int, datetime.datetime, Optional[str], str, int]
-# No corresponding class needed for this tuple.
+TupleTarsRow = Tuple[int, str, int, str]
+# No corresponding class needed for these tuples.
 TupleFilesRowNoId = Tuple[str, int, datetime.datetime, Optional[str], str, int]
+TupleTarsRowNoId = Tuple[str, int, Optional[str]]
 
 
-# Corresponding class to make accessing variables easier
+# Corresponding classes to make accessing variables easier
 class FilesRow(object):
     def __init__(self, t: TupleFilesRow):
         self.identifier: int = t[0]
@@ -62,3 +64,14 @@ class FilesRow(object):
             self.tar,
             self.offset,
         )
+
+
+class TarsRow(object):
+    def __init__(self, t: TupleTarsRow):
+        self.identifier: int = t[0]
+        self.name: str = t[1]
+        self.size: int = t[2]
+        self.md5: str = t[3]
+
+    def to_tuple(self) -> TupleTarsRow:
+        return (self.identifier, self.name, self.size, self.md5)

--- a/zstash/utils.py
+++ b/zstash/utils.py
@@ -7,7 +7,7 @@ import subprocess
 from fnmatch import fnmatch
 from typing import Any, List, Tuple
 
-from .settings import config, logger
+from .settings import TupleTarsRow, config, logger
 
 
 def exclude_files(exclude: str, files: List[str]) -> List[str]:
@@ -103,3 +103,25 @@ def update_config(cur: sqlite3.Cursor):
             value = cur.fetchone()[0]
             # Update config with the new attribute-value pair
             setattr(config, attr, value)
+
+
+def create_tars_table(cur: sqlite3.Cursor, con: sqlite3.Connection):
+    # Create 'tars' table
+    cur.execute(
+        u"""
+create table tars (
+id integer primary key,
+name text,
+size integer,
+md5 text
+);
+    """
+    )
+    con.commit()
+
+
+def tars_table_exists(cur: sqlite3.Cursor) -> bool:
+    # https://stackoverflow.com/questions/1601151/how-do-i-check-in-sqlite-whether-a-table-exists
+    cur.execute(u"PRAGMA table_info(tars);")
+    table_info_list: List[TupleTarsRow] = cur.fetchall()
+    return True if table_info_list != [] else False


### PR DESCRIPTION
Add checksum for tarball. Resolves #62 

- [x] `create` will set up a `tars` table
- [x] `ls` has an option to display the `tars` table
- [x] `update` will create a `tars` table if one doesn't exist. (Tested by adding an option to `create` to not set up the `tars` table).
- [x] Tests for `ls --tars`