### PR TITLE
Do not remove `copy_dir`

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -113,7 +113,7 @@ class TestZstash(unittest.TestCase):
         # self.cache may appear in any of these directories,
         # but should not appear at the same level as these.
         # Therefore, there is no need to explicitly remove it.
-        for d in [self.test_dir, self.backup_dir, self.copy_dir]:
+        for d in [self.test_dir, self.backup_dir]:
             if os.path.exists(d):
                 shutil.rmtree(d)
         if self.hpss_path and self.hpss_path.lower() != "none":


### PR DESCRIPTION
The fix for #159 actually causes the tests to delete the `zstash/zstash` directory. That is, a user running the tests will find that everything in `zstash/zstash` has been deleted afterward.

For reference, that fix was to run the tests from the top-level `zstash` directory and was part of #157. In `.github/workflows/build_workflow.yml`
```
          cd tests
          python -m unittest
```
was replaced with `python -m unittest tests/test_*.py`. In `tests/base.py`, `expected = "zstash/tests"` was replaced with `expected = "zstash"`.

In `tests/base.py`, we set `self.copy_dir = "zstash"`, which causes a name conflict with the `zstash/zstash` directory. The actual `copy_dir` is inside `test_dir`, so the removal command https://github.com/E3SM-Project/zstash/blob/master/tests/base.py#L116 actually simply ends ups removing `zstash/zstash`.

The solution is to not remove `self.copy_dir` since we're already removing `self.test_dir`.