### PR TITLE
Activate Globus endpoints before creating tarballs

### DIFF
--- a/zstash/create.py
+++ b/zstash/create.py
@@ -10,6 +10,7 @@ from typing import Any, List, Tuple
 
 from six.moves.urllib.parse import urlparse
 
+from .globus import globus_activate
 from .hpss import hpss_put
 from .hpss_utils import add_files
 from .settings import DEFAULT_CACHE, config, get_db_filename, logger
@@ -53,7 +54,9 @@ def create():
 
     if hpss != "none":
         url = urlparse(hpss)
-        if url.scheme != "globus":
+        if url.scheme == "globus":
+            globus_activate(hpss)
+        else:
             # config.hpss is not "none", so we need to
             # create target HPSS directory
             logger.debug("Creating target HPSS directory")

--- a/zstash/globus.py
+++ b/zstash/globus.py
@@ -8,6 +8,7 @@ import sys
 
 from fair_research_login.client import NativeClient
 from globus_sdk import TransferAPIError, TransferClient, TransferData
+from six.moves.urllib.parse import urlparse
 
 from .settings import logger
 
@@ -23,18 +24,28 @@ regex_endpoint_map = {
     r"cori.*\.nersc\.gov": "9d6d99eb-6d04-11e5-ba46-22000b92c6ec",
 }
 
+remote_endpoint = None
+local_endpoint = None
+transfer_client = None
 
-def globus_transfer(  # noqa: C901
-    remote_endpoint, remote_path, name, transfer_type, non_blocking=False
-):
+
+def globus_activate(hpss):
     """
     Read the local globus endpoint UUID from ~/.zstash.ini.
     If the ini file does not exist, create an ini file with empty values,
     and try to find the local endpoint UUID based on the FQDN
     """
+    global transfer_client
+    global local_endpoint
+    global remote_endpoint
+
+    url = urlparse(hpss)
+    if url.scheme != "globus":
+        return
+    remote_endpoint = url.netloc
+
     ini_path = os.path.expanduser("~/.zstash.ini")
     ini = configparser.ConfigParser()
-    local_endpoint = None
     if ini.read(ini_path):
         if "local" in ini.sections():
             local_endpoint = ini["local"].get("globus_endpoint_uuid")
@@ -59,6 +70,38 @@ def globus_transfer(  # noqa: C901
     if remote_endpoint.upper() in hpss_endpoint_map.keys():
         remote_endpoint = hpss_endpoint_map.get(remote_endpoint.upper())
 
+    native_client = NativeClient(
+        client_id="6c1629cf-446c-49e7-af95-323c6412397f",
+        app_name="Zstash",
+        default_scopes="openid urn:globus:auth:scope:transfer.api.globus.org:all",
+    )
+    native_client.login(no_local_server=True, refresh_tokens=True)
+    transfer_authorizer = native_client.get_authorizers().get("transfer.api.globus.org")
+    transfer_client = TransferClient(authorizer=transfer_authorizer)
+
+    for ep_id in [local_endpoint, remote_endpoint]:
+        r = transfer_client.endpoint_autoactivate(ep_id, if_expires_in=600)
+        if r.get("code") == "AutoActivationFailed":
+            logger.error(
+                "The {} endpoint is not activated or the current activation expires soon. Please go to https://app.globus.org/file-manager/collections/{} and (re)activate the endpoint.".format(
+                    ep_id, ep_id
+                )
+            )
+            sys.exit(1)
+
+
+def globus_transfer(  # noqa: C901
+    remote_ep, remote_path, name, transfer_type, non_blocking=False
+):
+    global transfer_client
+    global local_endpoint
+    global remote_endpoint
+
+    if not transfer_client:
+        globus_activate("globus://" + remote_ep)
+    if not transfer_client:
+        sys.exit(1)
+
     if transfer_type == "get":
         src_ep = remote_endpoint
         src_path = os.path.join(remote_path, name)
@@ -75,27 +118,8 @@ def globus_transfer(  # noqa: C901
     filename = name.split(".")[0]
     label = subdir_label + " " + filename
 
-    native_client = NativeClient(
-        client_id="6c1629cf-446c-49e7-af95-323c6412397f",
-        app_name="Zstash",
-        default_scopes="openid urn:globus:auth:scope:transfer.api.globus.org:all",
-    )
-    native_client.login(no_local_server=True, refresh_tokens=True)
-    transfer_authorizer = native_client.get_authorizers().get("transfer.api.globus.org")
-    tc = TransferClient(authorizer=transfer_authorizer)
-
-    for ep_id in [src_ep, dst_ep]:
-        r = tc.endpoint_autoactivate(ep_id, if_expires_in=600)
-        if r.get("code") == "AutoActivationFailed":
-            logger.error(
-                "The {} endpoint is not activated or the current activation expires soon. Please go to https://app.globus.org/file-manager/collections/{} and (re)activate the endpoint.".format(
-                    ep_id, ep_id
-                )
-            )
-            sys.exit(1)
-
     td = TransferData(
-        tc,
+        transfer_client,
         src_ep,
         dst_ep,
         label=label,
@@ -106,7 +130,7 @@ def globus_transfer(  # noqa: C901
     )
     td.add_item(src_path, dst_path)
     try:
-        task = tc.submit_transfer(td)
+        task = transfer_client.submit_transfer(td)
     except TransferAPIError as e:
         if e.code == "NoCredException":
             logger.error(
@@ -133,13 +157,13 @@ def globus_transfer(  # noqa: C901
         with 20 second timeout limit. If the task is ACTIVE after time runs
         out 'task_wait' returns False, and True otherwise.
         """
-        while not tc.task_wait(task_id, timeout=20, polling_interval=20):
+        while not transfer_client.task_wait(task_id, timeout=20, polling_interval=20):
             pass
         """
         The Globus transfer job (task) has been finished (SUCCEEDED or FAILED).
         Check if the transfer SUCCEEDED or FAILED.
         """
-        task = tc.get_task(task_id)
+        task = transfer_client.get_task(task_id)
         if task["status"] == "SUCCEEDED":
             logger.info(
                 "Globus transfer {}, from {}{} to {}{} succeeded".format(

--- a/zstash/update.py
+++ b/zstash/update.py
@@ -9,6 +9,7 @@ import sys
 from datetime import datetime
 from typing import List, Optional, Tuple
 
+from .globus import globus_activate
 from .hpss import hpss_get, hpss_put
 from .hpss_utils import add_files
 from .settings import (
@@ -116,6 +117,7 @@ def update_database(args: argparse.Namespace, cache: str) -> Optional[List[str]]
                 hpss: str = config.hpss
             else:
                 raise TypeError("Invalid config.hpss={}".format(config.hpss))
+            globus_activate(hpss)
             hpss_get(hpss, get_db_filename(cache), cache)
         else:
             error_str: str = (


### PR DESCRIPTION
Zstash commands `create` and `update` create a tarball and then transfer the tarball to HPSS using hsi or Globus. To transfer the tarball to a remote Globus endpoint, zstash needs a valid Globus OAuth2 access token and both local and remote Globus endpoints must be activated. If one of the conditions is not fulfilled, zstash will fails after spending even several minutes on creating the tarball. This PR moves the Globus initialization steps:

- getting an access token from the Globus Auth service,
- activating both remote and local Globus endpoints

before zstash creates a tarball.