### PR TITLE
Add regex matching Blues compute nodes to Globus endpoints mapping

### DIFF
--- a/zstash/globus.py
+++ b/zstash/globus.py
@@ -22,6 +22,7 @@ hpss_endpoint_map = {
 regex_endpoint_map = {
     r"theta.*\.alcf\.anl\.gov": "08925f04-569f-11e7-bef8-22000b9a448b",
     r"blueslogin.*\.lcrc\.anl\.gov": "61f9954c-a4fa-11ea-8f07-0a21f750d19b",
+    r"b\d+\.lcrc\.anl\.gov": "61f9954c-a4fa-11ea-8f07-0a21f750d19b",
     r"chr.*\.lcrc\.anl\.gov": "61f9954c-a4fa-11ea-8f07-0a21f750d19b",
     r"cori.*\.nersc\.gov": "9d6d99eb-6d04-11e5-ba46-22000b92c6ec",
     r"perlmutter.*\.nersc\.gov": "6bdc7956-fc0f-4ad2-989c-7aa5ee643a79",  # If this doesn't work, use cori


### PR DESCRIPTION
It solves https://github.com/E3SM-Project/zstash/issues/243 that was discussed here https://github.com/E3SM-Project/zstash/discussions/241.