### PR TITLE
Detect Perlmutter nodes and set corresponding Globus endpoint

### DIFF
--- a/zstash/globus.py
+++ b/zstash/globus.py
@@ -70,6 +70,13 @@ def globus_activate(hpss: str):
             if re.fullmatch(pattern, fqdn):
                 local_endpoint = regex_endpoint_map.get(pattern)
                 break
+    # FQDN is not set on Perlmutter at NERSC
+    if not local_endpoint:
+        nersc_hostname = os.environ.get("NERSC_HOST")
+        if nersc_hostname and (
+            nersc_hostname == "perlmutter" or nersc_hostname == "unknown"
+        ):
+            local_endpoint = regex_endpoint_map.get(r"perlmutter.*\.nersc\.gov")
     if not local_endpoint:
         logger.error(
             "{} does not have the local Globus endpoint set nor could one be found in regex_endpoint_map.".format(


### PR DESCRIPTION
NERSC Perlmutter nodes do not have an FQDN set properly. It means that `socket.getfqdn()` and regex cannot be used to determine what machine zstash is run on and set a corresponding Globus endpoint UUID. This PR adds another detection method that relies on `$NERSC_HOST` environment variable that is set on NERSC machines. If the variable is set to `"Perlmutter"` or "unknown", a Perlmutter Globus endpoint will be used for the machine zstash executed on.