### PR TITLE
Bump to v1.4.0rc2 without tbump

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zstash" %}
-{% set version = "1.4.0rc1" %}
+{% set version = "1.4.0rc2" %}
 
 package:
   name: {{ name|lower }}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="zstash",
-    version="1.4.0rc1",
+    version="1.4.0rc2",
     author="Ryan Forsyth, Chris Golaz, Zeshawn Shaheen",
     author_email="forsyth2@llnl.gov, golaz1@llnl.gov, shaheen2@llnl.gov",
     description="Long term HPSS archiving software for E3SM",

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/E3SM-Project/zstash.git"
 
 [version]
-current = "1.4.0rc1"
+current = "1.4.0rc2"
 
 # Example of a semver regexp with support for PEP 440
 # release candidates.Make sure this matches current_version

--- a/zstash/__init__.py
+++ b/zstash/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.4.0rc1"
+__version__ = "v1.4.0rc2"


### PR DESCRIPTION
Bump to v1.4.0rc2 without tbump.

Had to do this PR manually rather than using `tbump`. With `tbump`, I kept running into the following error:
```
[v1.4.0rc2 7199f03] Bump to 1.4.0rc2
 4 files changed, 4 insertions(+), 4 deletions(-)
To github.com:E3SM-Project/zstash.git
 ! [rejected]        main -> main (non-fast-forward)
error: failed to push some refs to 'github.com:E3SM-Project/zstash.git'
hint: Updates were rejected because a pushed branch tip is behind its remote
hint: counterpart. Check out this branch and integrate the remote changes
hint: (e.g. 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Command `git push upstream main` failed
```