### PR TITLE
Fix release workflow not publishing latest tags

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+  workflow_dispatch:
+
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
@@ -57,10 +59,11 @@ jobs:
           # Add `index.html` to point to the `main` branch automatically.
           printf '<meta http-equiv="refresh" content="0; url=./_build/html/main/index.html" />' > index.html
 
-          # Only replace `main` docs with latest changes. Docs for tags should be untouched.
-          rm -rf _build/html/main
-          mkdir -p _build/html/main
-          cp -r ../docs/_build/html/main _build/html
+          # Replace main docs to populate dropdown with latest tags
+          rm -r _build/html/main
+
+          # Only copy docs for main and current tag
+          cp -r -n ../docs/_build/html _build/
 
           # Configure git using GitHub Actions credentials.
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
I noticed the E3SM Diags release workflow wasn't copying the docs for v2.8.0 over to the gh-pages branch (related [PR](https://github.com/E3SM-Project/e3sm_diags/pull/698)). This caused the docs to break with a 404 if you tried clicking v2.8.0 in the dropdown.

The same thing is happening in zstash with [v1.3.0](https://e3sm-project.github.io/zstash/_build/html/v1.3.0/index.html). I updated the release workflow to correctly copy the tag docs. Once this is merged, we can rerun the release workflow manually to copy v1.3.0 docs over to gh-pages/

**Note, another 1.4.0 release candidate is not required for this fix because this is DevOps related.**