### PR TITLE
Update fair-research-login

### DIFF
--- a/conda/dev.yml
+++ b/conda/dev.yml
@@ -9,7 +9,7 @@ dependencies:
   - python=3.9.13
   - six=1.16.0
   - globus-sdk=3.2.1
-  - fair-research-login=0.2.0
+  - fair-research-login=0.2.6
   # Developer Tools
   # =================
   # If versions are updated, also update 'rev' in `.pre-commit.config.yaml`


### PR DESCRIPTION
Update `fair-research-login`.

This was actually necessary in #279 to get past the `additional_params` error (described in https://github.com/E3SM-Project/zstash/issues/274#issuecomment-1631562480). I created a dev environment using an updated `fair-research-login` but forgot to include those changes in #282. (The tests worked because the dev environment had the correct version of `fair-research-login` despite the branch not actually being updated).