### PR TITLE
Bump to 1.4.0

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zstash" %}
-{% set version = "1.4.0rc3" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="zstash",
-    version="1.4.0rc3",
+    version="1.4.0",
     author="Ryan Forsyth, Chris Golaz, Zeshawn Shaheen",
     author_email="forsyth2@llnl.gov, golaz1@llnl.gov, shaheen2@llnl.gov",
     description="Long term HPSS archiving software for E3SM",

--- a/tbump.toml
+++ b/tbump.toml
@@ -2,7 +2,7 @@
 github_url = "https://github.com/E3SM-Project/zstash.git"
 
 [version]
-current = "1.4.0rc3"
+current = "1.4.0"
 
 # Example of a semver regexp with support for PEP 440
 # release candidates.Make sure this matches current_version

--- a/zstash/__init__.py
+++ b/zstash/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "v1.4.0rc3"
+__version__ = "v1.4.0"


### PR DESCRIPTION
Bump to 1.4.0. Had to push manually because of https://github.com/E3SM-Project/zppy/issues/470.