### PR TITLE
Update supported python versions

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -16,11 +16,11 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python >=3.9
     - pip
 
   run:
-    - python >=3.6
+    - python >=3.9
     - fair-research-login >=0.2.6,<0.3.0
     - globus-sdk >=3.0.0,<4.0.0
     - six

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ exclude =
     venv
 
 [mypy]
-python_version = 3.7
+python_version = 3.9
 check_untyped_defs = True
 ignore_missing_imports = True
 warn_unused_ignores = True

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     author_email="forsyth2@llnl.gov, golaz1@llnl.gov, shaheen2@llnl.gov",
     description="Long term HPSS archiving software for E3SM",
     packages=find_packages(include=["zstash", "zstash.*"]),
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     entry_points={"console_scripts": ["zstash=zstash.main:main"]},
 )


### PR DESCRIPTION
Support for Python 3.8 (and lower) has been dropped from `conda-forge`, so I've updated the lower bounds of supported versions here accordingly.

---
Updated template from @forsyth2:

## Issue resolution
- Equivalent to https://github.com/E3SM-Project/e3sm_diags/pull/844

This pull request is a minor adjustment that would increment the patch version.

## 1. Does this do what we want it to do?

Objectives:
- Make Python 3.9 the oldest supported Python version in zstash.

Required:
- [x] Product Management: I have confirmed with the stakeholders that the objectives above are correct and complete.
- [ ] Testing: I have added at least one automated test. Every objective above is represented in at least one test.
  - Existing unit tests are sufficient to cover this change.
- [x] Testing: I have considered likely and/or severe edge cases and have included them in testing.

## 2. Are the implementation details accurate & efficient?

Required:
- [x] Logic: I have visually inspected the entire pull request myself.

## 3. Is this well documented?

Required:
- [ ] Documentation: by looking at the docs, a new user could easily understand the functionality introduced by this pull request.
 - This change does not require new documentation.

## 4. Is this code clean?

Required:
- [x] Readability: The code is as simple as possible and well-commented, such that a new team member could understand what's happening.
- [x] Pre-commit checks: All the pre-commits checks have passed.