### PR TITLE
Tweak behaviors of build and release CI workflows

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   pre-commit-hooks:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
     steps:
       - name: Checkout Code Repository
         uses: actions/checkout@v3
@@ -54,10 +54,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: zstash_dev
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           environment-file: conda/dev.yml
           channel-priority: strict
           auto-update-conda: true
@@ -99,10 +97,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: zstash_dev
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           environment-file: conda/dev.yml
           channel-priority: strict
           auto-update-conda: true

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -35,10 +35,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: zstash_dev
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           miniforge-version: latest
-          use-mamba: true
-          mamba-version: "*"
           environment-file: conda/dev.yml
           channel-priority: strict
           auto-update-conda: true


### PR DESCRIPTION
Hello! With this PR I've tweaked some settings that @xylar and I have determined work out better in CI workflows on other repos. I've made the same changes here. These changes include:
1. All references to `mamba`/`mambaforge` have been removed and/or changed to `conda` and `Miniforge3`
2. The timeout for the `pre-commit` job has been upped to 5 minutes

---
Updated template from @forsyth2:

## Issue resolution
- Equivalent to https://github.com/E3SM-Project/e3sm_diags/pull/847, https://github.com/E3SM-Project/zppy/pull/621

This pull request is a minor adjustment that does not affect functional code.

## 1. Does this do what we want it to do?

Objectives:
- Run CI with `Miniforge3` rather than `mamabforge`
- Run CI with a longer timeout for pre-commit checks, to ensure enough running time for these checks to pass.
- [Note: the `cancel_others` change present in the equivalent pull requests is not needed here, since here that parameter isn't in the file to begin with.]

Required:
- [x] Product Management: I have confirmed with the stakeholders that the objectives above are correct and complete.
- [ ] Testing: I have added at least one automated test. Every objective above is represented in at least one test.
  - The existing CI checks on GitHub check this.
- [x] Testing: I have considered likely and/or severe edge cases and have included them in testing.

## 2. Are the implementation details accurate & efficient?

Required:
- [x] Logic: I have visually inspected the entire pull request myself.

## 3. Is this well documented?

Required:
- [ ] Documentation: by looking at the docs, a new user could easily understand the functionality introduced by this pull request.
 - This change does not require new documentation.

## 4. Is this code clean?

Required:
- [x] Readability: The code is as simple as possible and well-commented, such that a new team member could understand what's happening.
- [x] Pre-commit checks: All the pre-commits checks have passed.